### PR TITLE
Implement create task

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,7 @@ jobs:
       - name: Run regression tests
         run: |
           poetry run python -m autogpt &
+          cp .env.example .env
           newman run https://raw.githubusercontent.com/Significant-Gravitas/devtool-postman/master/Postman%20Collections/devtool_experience.json --env-var "url= http://127.0.0.1:8000" || echo  "The backend is not ready yet, so the tests will fail"
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/autogpt/agent.py
+++ b/autogpt/agent.py
@@ -13,7 +13,8 @@ class AutoGPT:
         print(f"task: {task.input}")
         await Agent.db.create_step(task.task_id, task.input, is_last=True)
         time.sleep(2)
-        autogpt.utils.run(task.input)
+
+        # autogpt.utils.run(task.input) the task_handler only creates the task, it doesn't execute it
         # print(f"Created Task id: {task.task_id}")
         return task
 


### PR DESCRIPTION
Yay, more tests passing ! 

Commented the autogpt.utils.run(task.input) in case I am wrong.

But I am pretty sure the task_handler shouldn't execute the task. it should just create the task and return back an id.
