### PR TITLE
Add load tests Tasks CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,9 @@ jobs:
         run: |
           poetry run python -m autogpt &
           cp .env.example .env
-          newman run https://raw.githubusercontent.com/Significant-Gravitas/postman/master/Postman%20Collections/agent_protocol_rest.json --env-var "url= http://127.0.0.1:8000"
+          newman run https://raw.githubusercontent.com/Signifi
+          newman run https://raw.githubusercontent.com/Significant-Gravitas/postman/master/Postman%20Collections/agent_protocol_rest.json --folder "Basic User Experience" --env-var "url= http://127.0.0.1:8000" -n 2
+          newman run https://raw.githubusercontent.com/Significant-Gravitas/postman/master/Postman%20Collections/agent_protocol_rest.json --folder "Tasks Load Test" --env-var "url= http://127.0.0.1:8000" -n 10
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           AGENT_NAME: ${{ matrix.agent-name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,6 @@ jobs:
         run: |
           poetry run python -m autogpt &
           cp .env.example .env
-          newman run https://raw.githubusercontent.com/Signifi
           newman run https://raw.githubusercontent.com/Significant-Gravitas/postman/master/Postman%20Collections/agent_protocol_rest.json --folder "Basic User Experience" --env-var "url= http://127.0.0.1:8000" -n 2
           newman run https://raw.githubusercontent.com/Significant-Gravitas/postman/master/Postman%20Collections/agent_protocol_rest.json --folder "Tasks Load Test" --env-var "url= http://127.0.0.1:8000" -n 10
         env:


### PR DESCRIPTION
Apps shouldn't break when multiple calls per seconds, so let's have a load test for it:
Create Task, show task and get all tasks, 10 times in a row

https://documenter.getpostman.com/view/28411126/2s9Y5SVk9d
<img width="1233" alt="Screenshot 2023-08-18 at 2 19 30 PM" src="https://github.com/Significant-Gravitas/Auto-GPT-Forge/assets/9652976/317cbbe2-051c-49e8-ad1f-ac45fcc2ff24">
